### PR TITLE
Make error messages match other example repos

### DIFF
--- a/index.php
+++ b/index.php
@@ -35,7 +35,7 @@ $app->post('/checkouts', function () use ($app) {
         $errorString = "";
 
         foreach($result->errors->deepAll() AS $error) {
-            $errorString .= $error->code . "-" . $error->message . "\n";
+            $errorString .= 'Error: ' . $error->code . ": " . $error->message . "\n";
         }
 
         $_SESSION["errors"] = $errorString;

--- a/tests/integration/IndexPageTest.php
+++ b/tests/integration/IndexPageTest.php
@@ -137,7 +137,7 @@ class IndexPageTest extends PHPUnit_Framework_TestCase
         curl_setopt($curl, CURLOPT_COOKIEFILE, "");
         $output = curl_exec($curl);
         curl_close($curl);
-        $this->assertRegExp('/Cannot use a paymentMethodNonce more than once./', $output);
+        $this->assertRegExp('/Error: 91564: Cannot use a paymentMethodNonce more than once./', $output);
     }
 
     function test_transactionProcessorErrorRedirectsToCheckoutShowPage()


### PR DESCRIPTION
Change the error messages so that they are like the other repos, IE

```
Error: [Code]: [Message]
```
