### PR TITLE
Add Procfile and default to system env settings when dot-env file missing

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: php -S 0.0.0.0:$PORT

--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -1,8 +1,10 @@
 <?php
 session_start();
 
-$dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
-$dotenv->load();
+if(file_exists(__DIR__ . "/../.env")) {
+    $dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
+    $dotenv->load();
+}
 
 Braintree\Configuration::environment(getenv("BT_ENVIRONMENT"));
 Braintree\Configuration::merchantId(getenv("BT_MERCHANT_ID"));


### PR DESCRIPTION
We want to integrate a "Deploy to Heroku" button to enable people who do not have development experience to easily launch our example integration and explore the running application.

This PR updates our integration to be Heroku-compatible by adding a Procfile to specify how to start the app and defaulting to the system environment if a .env file is not present. Following this PR we will add the code to include a "Deploy to Heroku" button on the README.md.
