### PR TITLE
add submit for settlement by default

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,6 +22,9 @@ $app->post('/checkouts', function () use ($app) {
     $result = Braintree\Transaction::sale([
         "amount" => $app->request->post('amount'),
         "paymentMethodNonce" => $app->request->post('payment_method_nonce'),
+        'options' => [
+            'submitForSettlement' => True
+        ]
     ]);
 
     if($result->success || $result->transaction) {

--- a/tests/integration/IndexPageTest.php
+++ b/tests/integration/IndexPageTest.php
@@ -54,7 +54,10 @@ class IndexPageTest extends PHPUnit_Framework_TestCase
         $non_duplicate_amount = rand(1,100) . "." . rand(1,99);
         $result = Braintree\Transaction::sale([
             'amount' => $non_duplicate_amount,
-            'paymentMethodNonce' => 'fake-valid-nonce'
+            'paymentMethodNonce' => 'fake-valid-nonce',
+            'options' => [
+                'submitForSettlement' => True
+            ]
         ]);
         $transaction = $result->transaction;
         $curl = curl_init();


### PR DESCRIPTION
## Submit transactions for settlement by default

Currently, transactions are not submitted for settlement on the checkouts page. This would submit them automatically. For people using this repository to test out Braintree, this is useful as they don't have to manually submit each transaction they make in sandbox.