### PR TITLE
Use an instantiated gateway object instead of static method calls

### DIFF
--- a/includes/braintree_init.php
+++ b/includes/braintree_init.php
@@ -5,8 +5,3 @@ if(file_exists(__DIR__ . "/../.env")) {
     $dotenv = new Dotenv\Dotenv(__DIR__ . "/../");
     $dotenv->load();
 }
-
-Braintree\Configuration::environment(getenv("BT_ENVIRONMENT"));
-Braintree\Configuration::merchantId(getenv("BT_MERCHANT_ID"));
-Braintree\Configuration::publicKey(getenv("BT_PUBLIC_KEY"));
-Braintree\Configuration::privateKey(getenv("BT_PRIVATE_KEY"));

--- a/templates/checkouts/new.php
+++ b/templates/checkouts/new.php
@@ -37,7 +37,7 @@
     <script src="https://js.braintreegateway.com/web/dropin/1.9.2/js/dropin.min.js"></script>
     <script>
       var form = document.querySelector('#payment-form');
-      var client_token = "<?php echo(Braintree\ClientToken::generate()); ?>";
+      var client_token = "<?php echo($client_token); ?>";
 
       braintree.dropin.create({
         authorization: client_token,

--- a/tests/integration/IndexPageTest.php
+++ b/tests/integration/IndexPageTest.php
@@ -1,6 +1,13 @@
 <?php
 require_once("includes/braintree_init.php");
 
+$gateway = new Braintree\Gateway([
+    'environment' => getenv('BT_ENVIRONMENT'),
+    'merchantId' => getenv('BT_MERCHANT_ID'),
+    'publicKey' => getenv('BT_PUBLIC_KEY'),
+    'privateKey' => getenv('BT_PRIVATE_KEY')
+]);
+
 class IndexPageTest extends PHPUnit_Framework_TestCase
 {
     function test_rootReturnsHttpRedirect()
@@ -51,8 +58,9 @@ class IndexPageTest extends PHPUnit_Framework_TestCase
 
     function test_checkoutsShowContainsTransactionInformation()
     {
+        global $gateway;
         $non_duplicate_amount = rand(1,100) . "." . rand(1,99);
-        $result = Braintree\Transaction::sale([
+        $result = $gateway->transaction()->sale([
             'amount' => $non_duplicate_amount,
             'paymentMethodNonce' => 'fake-valid-nonce',
             'options' => [


### PR DESCRIPTION
Instantiating a gateway with merchant credentials supports a wider
range of authentication methods for all types of Braintree merchants.

@jferm 
@NickTomlin 